### PR TITLE
Allow user to specify additional separator after which the first letter should be capitalized

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
-module.exports = function(str) {
-  str = (str || '').toString().toLowerCase();
-  return str.replace(/(?:^|\s)\S/g, function(s) {
+module.exports = function(str, sep) {
+	str = (str || '').toString().toLowerCase();
+
+	sep = Array.isArray(sep) ? sep : (sep ? [sep] : []);
+	sep.push('\\s');
+
+  var r = new RegExp('(?:^|' + sep.join('|') + ')\\S', 'g');
+
+  return str.replace(r, function(s) {
     return s.toUpperCase();
   });
 };


### PR DESCRIPTION
Example usage:

```
var name = toProperUpper("tina o'donnell", "'"); // Tina O'Donnell
var str = toProperUpper("some_string", "_"); // Some_String
```
